### PR TITLE
fix: explicitly destroy response stream to prevent resource leak

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@juzi/file-box",
-  "version": "1.7.20",
+  "version": "1.8.2",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@juzi/file-box",
-      "version": "1.7.20",
+      "version": "1.8.2",
       "license": "Apache-2.0",
       "dependencies": {
         "brolog": "^1.14.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@juzi/file-box",
-  "version": "1.8.1",
+  "version": "1.8.2",
   "description": "Pack a File into Box for easy move/transfer between servers no matter of where it is.(local path, remote url, or cloud storage)",
   "type": "module",
   "exports": {


### PR DESCRIPTION
## Summary

修复 HTTP 响应流资源泄漏问题，显式销毁响应流以释放底层 socket 资源。

## 核心改进

**问题**：在下载失败或回退场景下，`http.IncomingMessage` 响应流可能未被正确关闭，导致：
- 底层 socket 资源泄漏
- 连接未释放，影响后续请求

**解决方案**：
- 在 `finally` 块中显式调用 `res?.destroy()` 释放资源
- 使用可选链 `?.` 避免 `res` 未定义的情况（fetch 失败时）
- 修正 `res` 类型为 `http.IncomingMessage | undefined`

**代码变更**：
```typescript
let res: http.IncomingMessage | undefined  // ← 正确的类型定义
try {
  res = await fetch(url, requestOptions, proxyUrl)
  // ... pipeline 处理
} catch (error) {
  // ... 错误处理
} finally {
  // 显式销毁响应流，释放底层 socket 资源
  // pipeline 成功时会自动关闭流，但失败时可能保持打开状态
  res?.destroy()  // ← 关键修复
}
```

## 覆盖场景

- ✅ 成功场景：pipeline 已关闭流，`destroy()` 无操作（幂等）
- ✅ 失败重试：显式关闭，释放资源
- ✅ FallbackError 回退：显式关闭，避免泄漏
- ✅ fetch 失败：`res` 为 undefined，可选链安全

## 版本升级

- 从 `1.8.1` → `1.8.2`
- Patch 版本：修复资源泄漏 bug

## Test plan

- [x] 所有单元测试通过（116 个断言全部通过）
- [x] 分片下载测试正常
- [x] 错误重试场景正常
- [x] 超时场景正常
- [x] 资源管理正确

```
Suites:   12 passed, 12 of 12 completed
Asserts:  116 passed, of 116
Time:     1m 12s
```

## Breaking Changes

无破坏性变更。完全向后兼容。

## Notes

这是一个重要的资源管理修复，建议尽快合并并发布。