### PR TITLE
fix(misc): CMSV6 服务器对带 Range 请求返回 200 + 错误内容时自动回退

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@juzi/file-box",
-  "version": "1.8.2",
+  "version": "1.8.5",
   "description": "Pack a File into Box for easy move/transfer between servers no matter of where it is.(local path, remote url, or cloud storage)",
   "type": "module",
   "exports": {

--- a/src/misc.spec.ts
+++ b/src/misc.spec.ts
@@ -273,3 +273,41 @@ test('httpStream: 带 Range 却收到 200 时回退重发不带 Range(B1 - CMSV6
   t.equal(getRangeHeaderByCall[1], undefined, '第 2 次 GET 不应携带 Range header')
   t.equal(buffer.toString('utf8'), TRUE_DATA.toString('utf8'), '最终数据应为 TRUE_DATA(回退后拿到的)')
 })
+
+test('httpStream: 黑名单登记的 host 后续请求直接跳过 Range(B1 黑名单持久化)', async (t) => {
+  __clearUnsupportedRangeDomains()
+
+  const TRUE_DATA = Buffer.from('SECOND-DOWNLOAD-AFTER-BLACKLIST', 'utf8')
+  let getCallCount = 0
+  let getHadRangeHeader: boolean | undefined
+
+  const server = createServer((req, res) => {
+    if (req.method === 'HEAD') {
+      res.writeHead(200, { 'Content-Length': String(TRUE_DATA.length) })
+      res.end()
+      return
+    }
+    getCallCount += 1
+    getHadRangeHeader = 'range' in req.headers
+    res.writeHead(200, { 'Content-Length': String(TRUE_DATA.length) })
+    res.end(TRUE_DATA)
+  })
+
+  const port = await new Promise<number>((resolve) => {
+    server.listen(0, '127.0.0.1', () => {
+      const addr = server.address() as AddressInfo
+      resolve(addr.port)
+    })
+  })
+  t.teardown(() => { server.close() })
+
+  // 测试前手工 seed hostKey 进黑名单,模拟"此前已因 B1 加入过"
+  __addUnsupportedRangeDomain(`127.0.0.1:${port}`)
+
+  const stream = await httpStream(`http://127.0.0.1:${port}/file`)
+  const buffer = await streamToBuffer(stream)
+
+  t.equal(getCallCount, 1, '黑名单命中后 GET 只调用 1 次')
+  t.equal(getHadRangeHeader, false, '黑名单命中后 GET 不带 Range header')
+  t.equal(buffer.toString('utf8'), TRUE_DATA.toString('utf8'), '应拿到真实数据')
+})

--- a/src/misc.spec.ts
+++ b/src/misc.spec.ts
@@ -12,6 +12,8 @@ import {
   httpHeadHeader,
   httpStream,
   streamToBuffer,
+  __clearUnsupportedRangeDomains,
+  __addUnsupportedRangeDomain,
 } from './misc.js'
 
 // 设置短超时用于测试
@@ -186,4 +188,42 @@ test('httpStream in chunks', async (t) => {
   const res = await httpStream(`${host}/file`)
   const buffer = await streamToBuffer(res)
   t.equal(buffer.length, FILE_SIZE, 'should get data in chunks right')
+})
+
+test('httpStream: HEAD Accept-Ranges=none 时不发 Range 请求(A2)', async (t) => {
+  __clearUnsupportedRangeDomains()
+
+  const TRUE_DATA = Buffer.from('TRUE-DATA-A2', 'utf8')
+  let getCallCount = 0
+  let getHadRangeHeader: boolean | undefined
+
+  const server = createServer((req, res) => {
+    if (req.method === 'HEAD') {
+      res.writeHead(200, {
+        'Accept-Ranges': 'none',
+        'Content-Length': String(TRUE_DATA.length),
+      })
+      res.end()
+      return
+    }
+    getCallCount += 1
+    getHadRangeHeader = 'range' in req.headers
+    res.writeHead(200, { 'Content-Length': String(TRUE_DATA.length) })
+    res.end(TRUE_DATA)
+  })
+
+  const host = await new Promise<string>((resolve) => {
+    server.listen(0, '127.0.0.1', () => {
+      const addr = server.address() as AddressInfo
+      resolve(`http://127.0.0.1:${addr.port}`)
+    })
+  })
+  t.teardown(() => { server.close() })
+
+  const stream = await httpStream(`${host}/file`)
+  const buffer = await streamToBuffer(stream)
+
+  t.equal(getCallCount, 1, 'GET 应只被调用 1 次')
+  t.equal(getHadRangeHeader, false, 'GET 请求不应携带 Range header')
+  t.equal(buffer.toString('utf8'), TRUE_DATA.toString('utf8'), '应拿到真实数据')
 })

--- a/src/misc.spec.ts
+++ b/src/misc.spec.ts
@@ -228,6 +228,51 @@ test('httpStream: HEAD Accept-Ranges=none 时不发 Range 请求(A2)', async (t)
   t.equal(buffer.toString('utf8'), TRUE_DATA.toString('utf8'), '应拿到真实数据')
 })
 
+test('httpStream: HEAD Accept-Ranges=none 端到端持久化,第二次请求直接跳过 Range(A2 持久化)', async (t) => {
+  __clearUnsupportedRangeDomains()
+
+  const TRUE_DATA = Buffer.from('E2E-A2-PERSISTENCE', 'utf8')
+  let getCallCount = 0
+  const getRangeHeaderByCall: (string | undefined)[] = []
+
+  const server = createServer((req, res) => {
+    if (req.method === 'HEAD') {
+      res.writeHead(200, {
+        'Accept-Ranges': 'none',
+        'Content-Length': String(TRUE_DATA.length),
+      })
+      res.end()
+      return
+    }
+    getCallCount += 1
+    const rangeHeader = req.headers.range
+    getRangeHeaderByCall.push(typeof rangeHeader === 'string' ? rangeHeader : undefined)
+    res.writeHead(200, { 'Content-Length': String(TRUE_DATA.length) })
+    res.end(TRUE_DATA)
+  })
+
+  const host = await new Promise<string>((resolve) => {
+    server.listen(0, '127.0.0.1', () => {
+      const addr = server.address() as AddressInfo
+      resolve(`http://127.0.0.1:${addr.port}`)
+    })
+  })
+  t.teardown(() => { server.close() })
+
+  // 第一次请求:HEAD 里 Accept-Ranges=none,A2 把 host 加入黑名单
+  const stream1 = await httpStream(`${host}/file`)
+  await streamToBuffer(stream1)
+
+  // 第二次请求:同 host,预期 A2 黑名单命中,GET 不带 Range
+  const stream2 = await httpStream(`${host}/file`)
+  const buffer2 = await streamToBuffer(stream2)
+
+  t.equal(getCallCount, 2, 'GET 应被调用 2 次(每次请求各 1 次,无 Range 重试)')
+  t.equal(getRangeHeaderByCall[0], undefined, '第 1 次 GET 不带 Range(本次 HEAD 已宣告 none)')
+  t.equal(getRangeHeaderByCall[1], undefined, '第 2 次 GET 不带 Range(黑名单命中)')
+  t.equal(buffer2.toString('utf8'), TRUE_DATA.toString('utf8'), '第二次应拿到真实数据')
+})
+
 test('httpStream: 带 Range 却收到 200 时回退重发不带 Range(B1 - CMSV6 场景)', async (t) => {
   __clearUnsupportedRangeDomains()
 

--- a/src/misc.spec.ts
+++ b/src/misc.spec.ts
@@ -227,3 +227,49 @@ test('httpStream: HEAD Accept-Ranges=none 时不发 Range 请求(A2)', async (t)
   t.equal(getHadRangeHeader, false, 'GET 请求不应携带 Range header')
   t.equal(buffer.toString('utf8'), TRUE_DATA.toString('utf8'), '应拿到真实数据')
 })
+
+test('httpStream: 带 Range 却收到 200 时回退重发不带 Range(B1 - CMSV6 场景)', async (t) => {
+  __clearUnsupportedRangeDomains()
+
+  const FAKE_DATA = Buffer.from('FAKE-DATA-FROM-WRONG-STREAM', 'utf8')
+  const TRUE_DATA = Buffer.alloc(FAKE_DATA.length, 'T') // 长度相同,内容不同
+  let getCallCount = 0
+  const getRangeHeaderByCall: (string | undefined)[] = []
+
+  const server = createServer((req, res) => {
+    if (req.method === 'HEAD') {
+      // 注意:不返回 Accept-Ranges,模拟 CMSV6
+      res.writeHead(200, { 'Content-Length': String(TRUE_DATA.length) })
+      res.end()
+      return
+    }
+    getCallCount += 1
+    const rangeHeader = req.headers.range
+    getRangeHeaderByCall.push(typeof rangeHeader === 'string' ? rangeHeader : undefined)
+
+    // CMSV6 行为:无论是否带 Range,都返回 200 + 正确 Content-Length
+    // 但内容随 Range 存在与否而不同
+    res.writeHead(200, { 'Content-Length': String(TRUE_DATA.length) })
+    if (rangeHeader) {
+      res.end(FAKE_DATA)
+    } else {
+      res.end(TRUE_DATA)
+    }
+  })
+
+  const host = await new Promise<string>((resolve) => {
+    server.listen(0, '127.0.0.1', () => {
+      const addr = server.address() as AddressInfo
+      resolve(`http://127.0.0.1:${addr.port}`)
+    })
+  })
+  t.teardown(() => { server.close() })
+
+  const stream = await httpStream(`${host}/file`)
+  const buffer = await streamToBuffer(stream)
+
+  t.equal(getCallCount, 2, 'GET 应被调用 2 次(第一次带 Range 触发 B1,第二次回退)')
+  t.ok(getRangeHeaderByCall[0], '第 1 次 GET 应携带 Range header')
+  t.equal(getRangeHeaderByCall[1], undefined, '第 2 次 GET 不应携带 Range header')
+  t.equal(buffer.toString('utf8'), TRUE_DATA.toString('utf8'), '最终数据应为 TRUE_DATA(回退后拿到的)')
+})

--- a/src/misc.ts
+++ b/src/misc.ts
@@ -36,6 +36,16 @@ class FallbackError extends Error {
 
 }
 
+// 仅测试用:清空运行期黑名单(模块级 Set 跨 test 会污染)
+export function __clearUnsupportedRangeDomains (): void {
+  unsupportedRangeDomains.clear()
+}
+
+// 仅测试用:手工登记一个 host 到黑名单(用于验证后续请求直接跳过 Range)
+export function __addUnsupportedRangeDomain (hostKey: string): void {
+  unsupportedRangeDomains.add(hostKey)
+}
+
 function getProtocol (protocol: string) {
   assert(protocolMap[protocol], new Error('unknown protocol: ' + protocol))
   return protocolMap[protocol]!

--- a/src/misc.ts
+++ b/src/misc.ts
@@ -24,7 +24,26 @@ const protocolMap: {
 }
 
 const noop = () => { }
+
+// 运行期黑名单:记录已知不支持 Range 请求的 host(格式 `hostname:port`)
+// 用 Set 天然按插入序保序,命中上限时淘汰最早插入的条目(FIFO)
+// 上限防止长运行进程(如网关)内存无界增长
+const UNSUPPORTED_RANGE_DOMAINS_MAX = 1024
 const unsupportedRangeDomains = new Set<string>()
+
+function addUnsupportedRangeDomain (hostKey: string): void {
+  if (unsupportedRangeDomains.has(hostKey)) {
+    return
+  }
+  unsupportedRangeDomains.add(hostKey)
+  if (unsupportedRangeDomains.size > UNSUPPORTED_RANGE_DOMAINS_MAX) {
+    // Set.values() 按插入顺序迭代,删除最早一条即可
+    const oldest = unsupportedRangeDomains.values().next().value
+    if (oldest !== undefined) {
+      unsupportedRangeDomains.delete(oldest)
+    }
+  }
+}
 
 // 自定义 Error：标记需要回退到非分片下载
 class FallbackError extends Error {
@@ -43,7 +62,7 @@ export function __clearUnsupportedRangeDomains (): void {
 
 // 仅测试用:手工登记一个 host 到黑名单(用于验证后续请求直接跳过 Range)
 export function __addUnsupportedRangeDomain (hostKey: string): void {
-  unsupportedRangeDomains.add(hostKey)
+  addUnsupportedRangeDomain(hostKey)
 }
 
 function getProtocol (protocol: string) {
@@ -133,7 +152,7 @@ export async function httpStream (url: string, headers: http.OutgoingHttpHeaders
   const acceptRangesRaw = headHeaders['accept-ranges']
   const acceptRanges = Array.isArray(acceptRangesRaw) ? acceptRangesRaw[0] : acceptRangesRaw
   if (typeof acceptRanges === 'string' && acceptRanges.trim().toLowerCase() === 'none') {
-    unsupportedRangeDomains.add(hostKey)
+    addUnsupportedRangeDomain(hostKey)
   }
 
   // 直接尝试分片下载，不检查 fileSize
@@ -274,7 +293,6 @@ async function downloadFileInChunks (
   let retries = 3
   // 控制是否使用 Range 请求（根据域名黑名单初始化）
   let useRange = !unsupportedRangeDomains.has(hostKey)
-  let useChunked = false
 
   do {
     // 每次循环前检查文件实际大小，作为真实的下载进度
@@ -342,9 +360,6 @@ async function downloadFileInChunks (
           throw new Error(`File size mismatch: expected ${expectedTotal}, but server returned ${total}`)
         }
 
-        // 标记使用了分片下载
-        useChunked = true
-
         // 验证服务器返回的范围是否与请求匹配
         if (actualStart !== start) {
           if (actualStart > start) {
@@ -376,17 +391,9 @@ async function downloadFileInChunks (
           throw new FallbackError('Server returned 200 for Range request')
         }
         // 200: 服务器返回完整文件（本次未带 Range）
-        if (useChunked || start > 0) {
-          // 之前以分片模式下载过数据
-          writeStream.destroy()
-          await rm(tmpFile, { force: true }).catch(() => {})
-          writeStream = createWriteStream(tmpFile)
-          writeStream.on('error', onWriteError)
-          start = 0
-          downSize = 0
-        }
-
-        // 处理完整文件响应
+        // B1 保证带 Range 收 200 一定经 FallbackError 回退,catch 里已重置
+        // expectedTotal/downSize/start/useRange,进入此分支时一定是
+        // 全新的非 Range 请求,无须再清理已写数据
         expectedTotal = contentLength
         await pipeline(res, writeStream, { end: false, signal })
         downSize = contentLength
@@ -399,7 +406,7 @@ async function downloadFileInChunks (
     } catch (error) {
       if (error instanceof FallbackError) {
         // 回退逻辑：记录域名、重置状态，在下次循环中以非 range 模式请求
-        unsupportedRangeDomains.add(hostKey)
+        addUnsupportedRangeDomain(hostKey)
 
         // 关闭当前写入流
         writeStream.destroy()
@@ -418,7 +425,6 @@ async function downloadFileInChunks (
         expectedTotal = null
         downSize = 0
         start = 0
-        useChunked = false
         useRange = false
         retries = 3
         continue

--- a/src/misc.ts
+++ b/src/misc.ts
@@ -127,11 +127,20 @@ export async function httpStream (url: string, headers: http.OutgoingHttpHeaders
   const defaultPort = protocol === 'https:' ? '443' : '80'
   const hostKey = `${hostname}:${port || defaultPort}`
 
-  // 直接尝试分片下载，不检查 Accept-Ranges 和 fileSize
+  // A2：若 HEAD 明确声明 Accept-Ranges: none，记录到运行期黑名单
+  // 以便 downloadFileInChunks 本次请求就直接以非 Range 模式发起
+  // Accept-Ranges header 可能是 string | string[]，归一化后匹配 'none'
+  const acceptRangesRaw = headHeaders['accept-ranges']
+  const acceptRanges = Array.isArray(acceptRangesRaw) ? acceptRangesRaw[0] : acceptRangesRaw
+  if (typeof acceptRanges === 'string' && acceptRanges.trim().toLowerCase() === 'none') {
+    unsupportedRangeDomains.add(hostKey)
+  }
+
+  // 直接尝试分片下载，不检查 fileSize
   // 原因：
   // 1. 有些服务器 HEAD 不返回 Accept-Ranges 但实际支持分片
   // 2. 有些服务器 HEAD 返回 fileSize=0 但实际支持分片
-  // downloadFileInChunks 内部有完善的回退机制处理不支持的情况
+  // downloadFileInChunks 内部有完善的回退机制处理不支持的情况（见 B1）
   const result = await downloadFileInChunks(url, options, proxyUrl, hostKey)
   return result
 }

--- a/src/misc.ts
+++ b/src/misc.ts
@@ -369,7 +369,13 @@ async function downloadFileInChunks (
         downSize += end - start + 1
         start = downSize
       } else if (res.statusCode === 200) {
-        // 200: 服务器返回完整文件
+        if (useRange) {
+          // B1：发了 Range 却收到 200 —— 服务器未实现 Range
+          // 响应体是"对带 Range 请求的回答"，不可信（见 CMSV6 场景）
+          // 交给 FallbackError 的 catch 分支统一处理：销毁流、删 tmp、加入黑名单、重发
+          throw new FallbackError('Server returned 200 for Range request')
+        }
+        // 200: 服务器返回完整文件（本次未带 Range）
         if (useChunked || start > 0) {
           // 之前以分片模式下载过数据
           writeStream.destroy()

--- a/src/misc.ts
+++ b/src/misc.ts
@@ -252,7 +252,7 @@ async function downloadFileInChunks (
   url: string,
   options: http.RequestOptions,
   proxyUrl: string | undefined,
-  hostname: string,
+  hostKey: string,
 ): Promise<Readable> {
   const tmpFile = join(tmpdir(), `filebox-${randomUUID()}`)
   let writeStream = createWriteStream(tmpFile)
@@ -273,7 +273,7 @@ async function downloadFileInChunks (
   let downSize = 0
   let retries = 3
   // 控制是否使用 Range 请求（根据域名黑名单初始化）
-  let useRange = !unsupportedRangeDomains.has(hostname)
+  let useRange = !unsupportedRangeDomains.has(hostKey)
   let useChunked = false
 
   do {
@@ -399,7 +399,7 @@ async function downloadFileInChunks (
     } catch (error) {
       if (error instanceof FallbackError) {
         // 回退逻辑：记录域名、重置状态，在下次循环中以非 range 模式请求
-        unsupportedRangeDomains.add(hostname)
+        unsupportedRangeDomains.add(hostKey)
 
         // 关闭当前写入流
         writeStream.destroy()


### PR DESCRIPTION
## 背景

CMSV6 车载视频监控服务器(\`Version: CMSV6 Web 7.25.0.1\`)对带 \`Range: bytes=0-\` 的请求返回 200 + 正确 \`Content-Length\`,但响应体是错误的**另一路子码流图片**(非请求的主码流)。file-box 当前策略"直接尝试分片下载,不检查 Accept-Ranges"会把错误图片当完整内容接受,且不加入黑名单,后续请求持续返回错误数据。

实测案例同一摄像头同一时刻:

| | 不带 Range | 带 \`Range: bytes=0-\` |
|---|---|---|
| 状态码 | 200 | 200(不是 206) |
| Content-Length | 110723 | 110723 |
| 分辨率 | 1280×720(主码流) | 704×576(子码流) |
| MD5 | \`a2353d3e307c4ba2d515e403b4be1ca6\` | \`dfc37ae54002dec411705f439efad33b\` |

## Summary

- **A2**: \`httpStream\` 读 HEAD 后,若 \`Accept-Ranges\` 归一化(trim + lowercase,支持 \`string[]\`)为 \`none\`,把 \`hostname:port\` 加入运行期黑名单,跳过本次 Range 尝试
- **B1**: \`downloadFileInChunks\` 的 200 分支最前面加 \`if (useRange) throw new FallbackError(...)\`,借既有 catch 分支完成清理/黑名单登记/重发(不带 Range)
- 运行期黑名单封装 \`addUnsupportedRangeDomain\`,FIFO 淘汰超过 1024 条目的旧 host,防止长运行进程内存无界增长
- 清理 200 分支下 B1 生效后不可达的死代码(\`useChunked\` 变量与 \`useChunked || start > 0\` 清理分支)

## Test plan

- [x] T1 单元测试:HEAD \`Accept-Ranges: none\` 时 GET 不带 Range 且一次命中
- [x] T2 单元测试:模拟 CMSV6 行为(带 Range 收 200 + 错误数据),验证 GET 调用 2 次且最终拿到真实数据
- [x] T3 单元测试:黑名单 seed 后同 host 请求直接跳过 Range
- [x] T4 单元测试:A2 端到端持久化 —— HEAD 声明 \`none\` 后同 host 第二次请求自动跳过 Range
- [x] 既有测试无回归,全量 12 个 test files 通过
- [x] \`tsc --isolatedModules --noEmit\` 干净
- [x] \`eslint\` 干净
- [x] **真实 URL 端到端验证**: \`FileBox.fromUrl(cmsv6Url).toBuffer()\` 返回 MD5 \`a2353d3e307c4ba2d515e403b4be1ca6\`,分辨率 1280×720

## 设计文档

- \`docs/superpowers/specs/2026-05-13-cmsv6-range-fallback-design.md\`
- \`docs/superpowers/plans/2026-05-13-cmsv6-range-fallback.md\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)